### PR TITLE
Add an integration test for consistency with common-definitions

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -1,0 +1,30 @@
+# This workflow checks that no conflicts exist with the common-definitions repo
+
+name: Check consistency with common-definitions
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ '**' ]
+  schedule:
+    - cron:  '45 5 * * *'
+
+jobs:
+  project-validation:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.11
+
+    - name: Install requirements
+      run: pip install nomenclature-iamc pytest
+
+    - name: Run the integration test
+      run: pytest tests/test_integration.py

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -27,4 +27,4 @@ jobs:
       run: pip install nomenclature-iamc pytest
 
     - name: Run the integration test
-      run: pytest tests/test_integration.py
+      run: pytest tests/test_integration.py --rootdir='tests'

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 ### common-definitions ###
 common-definitions
+nomenclature.yaml
+
 ### IntelliJ PyCharm ###
 .idea/
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 ### common-definitions ###
 common-definitions
-nomenclature.yaml
 
 ### IntelliJ PyCharm ###
 .idea/

--- a/definitions/variable/variable.yaml
+++ b/definitions/variable/variable.yaml
@@ -513,12 +513,6 @@
 - Consumption:
     definition: total consumption of all goods, by all consumers in a region
     unit: billion US$2010/yr
-- GDP|MER:
-    definition: GDP at market exchange rate
-    unit: billion US$2010/yr
-- GDP|PPP:
-    definition: GDP converted to International $ using purchasing power parity (PPP)
-    unit: billion US$2010/yr
 - Value Added|Agriculture:
     definition: value added of the agricultural sector
     unit: billion US$2010/yr

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,27 @@
+import pathlib
+import yaml
+
+import nomenclature
+
+
+def test_integration_common_definitions():
+
+    config_file = "../definitions/nomenclature.yaml"
+    config = {
+        "repositories": {
+            "common-definitions": {
+                "url": "https://github.com/IAMconsortium/common-definitions.git/"
+            }
+        },
+        "definitions": {
+            "region": {"repository": "common-definitions"},
+            "variable": {"repository": "common-definitions"},
+        },
+    }
+
+    with open(config_file, "w") as file:
+        yaml.dump(config, file)
+
+    nomenclature.DataStructureDefinition("../definitions")
+
+    pathlib.Path(config_file).unlink()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -22,6 +22,8 @@ def test_integration_common_definitions():
     with open(config_file, "w") as file:
         yaml.dump(config, file)
 
-    nomenclature.DataStructureDefinition("definitions")
+    try:
+        nomenclature.DataStructureDefinition("definitions")
 
-    pathlib.Path(config_file).unlink()
+    finally:
+        pathlib.Path(config_file).unlink()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -6,7 +6,7 @@ import nomenclature
 
 def test_integration_common_definitions():
 
-    config_file = "../definitions/nomenclature.yaml"
+    config_file = "nomenclature.yaml"
     config = {
         "repositories": {
             "common-definitions": {
@@ -22,6 +22,6 @@ def test_integration_common_definitions():
     with open(config_file, "w") as file:
         yaml.dump(config, file)
 
-    nomenclature.DataStructureDefinition("../definitions")
+    nomenclature.DataStructureDefinition("definitions")
 
     pathlib.Path(config_file).unlink()


### PR DESCRIPTION
Remove GDP variables following the merging of https://github.com/IAMconsortium/common-definitions/pull/54 and add an integration-test to ensure consistency between common-definitions & legacy definitions.