### PR TITLE
"Unemployment" moved to common-definitions

### DIFF
--- a/definitions/variable/variable.yaml
+++ b/definitions/variable/variable.yaml
@@ -792,9 +792,6 @@
       CO2, CH4, N2O and F-gases (preferably use 100-year GWPs from AR4 for aggregation
       of different gases, net of bioenergy with CCS (BECCS)
     unit: Mt CO2-equiv/yr
-- Employment:
-    definition: Number of employed inhabitants (based on ILO classification)
-    unit: million
 - Unemployment|Rate:
     definition: Fraction of unemployed inhabitants (based on ILO classification)
     unit: '%'

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -31,7 +31,7 @@ def test_integration_common_definitions():
             for project in ["navigate", "engage", "shape"]:
                 if project in attrs.extra_attributes:
                     legacy_var = attrs.__getattr__(project)
-                    if legacy_var in existing_variables:
+                    if legacy_var != code and legacy_var in existing_variables:
                         legacy_variables[legacy_var] = code
 
         if legacy_variables:


### PR DESCRIPTION
This PR removes "Unemployment" from the legacy-definitions because a renamed variable with the same interpretation was added to common-definitions.

FYI @phackstock 